### PR TITLE
Small typo fixes.

### DIFF
--- a/Projects/Project_2/Compiler/Parser.fsy
+++ b/Projects/Project_2/Compiler/Parser.fsy
@@ -144,4 +144,4 @@ Exp:
   | Exp LT Exp                        { Apply("<", [$1; $3])}
   | Exp NEQ Exp                       { Apply("<>", [$1; $3])}
   | NAME LP ExpL RP                   { Apply($1, $3) }
-  | LP Exp RP QMARK Exp COLON Exp     { Apply("?:", [$1; $3; $5]) }
+  | LP Exp RP QMARK Exp COLON Exp     { Apply("?:", [$2; $5; $7]) }

--- a/Projects/Project_2/Tests/StringTests.fs
+++ b/Projects/Project_2/Tests/StringTests.fs
@@ -33,4 +33,4 @@ type StringTests() =
     //expect an error because chars should not contain strings
     [<TestMethod>]
     member this.CharNotStringFail () =
-        Assert.ThrowsException (fun t -> exec "programs/CharNotStringFail.gc") ;
+        Assert.ThrowsException (fun t -> exec "programs/CharNotStringFail.gc") |> ignore

--- a/Projects/Project_2/Tests/Tests.fsproj
+++ b/Projects/Project_2/Tests/Tests.fsproj
@@ -91,5 +91,6 @@
     <Copy SourceFiles="..\programs\PreincDecLoop.gc" DestinationFolder="$(OutDir)programs" />
     <Copy SourceFiles="..\programs\PreincrementOnBoolFail.gc" DestinationFolder="$(OutDir)programs" />
     <Copy SourceFiles="..\programs\PredecrementLoop.gc" DestinationFolder="$(OutDir)programs" />
+    <Copy SourceFiles="..\programs\PreincDecAccessTypes.gc" DestinationFolder="$(OutDir)programs" />
   </Target>
 </Project>


### PR DESCRIPTION
All tests shows green now; had a typo in the parser (when adding parenthesies to ternary oprs)